### PR TITLE
Better check for data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.0.1
+- Check for "'data':" not "data"
+
 ## 1.0.0
 - Code reviewed by pubnub team, corrected reconnect policy.
 

--- a/pubnubsubhandler.py
+++ b/pubnubsubhandler.py
@@ -171,7 +171,7 @@ class PubNubSubCallback(SubscribeCallback):
         to channels.
         Proccess the message and call the channels callback function(s).
         """
-        if 'data' in message.message:
+        if '\'data\':' in message.message:
             json_data = json.dumps(message.message.get('data'))
         else:
             json_data = message.message

--- a/pubnubsubhandler.py
+++ b/pubnubsubhandler.py
@@ -171,9 +171,9 @@ class PubNubSubCallback(SubscribeCallback):
         to channels.
         Proccess the message and call the channels callback function(s).
         """
-        if '\'data\':' in message.message:
+        try:
             json_data = json.dumps(message.message.get('data'))
-        else:
+        except AttributeError:
             json_data = message.message
         for func in SUBSCRIPTIONS[message.channel]:
             # This means pubnub couldn't get the current state of the channel

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pubnubsub-handler',
-    version='1.0.0',
+    version='1.0.1',
     description='Handles the PubNub subscriptions between PubNub and Home-Assistant for Wink',
     url='https://github.com/w1ll1am23/pubnubsub-handler',
     author='William Scanlon',


### PR DESCRIPTION
Pubnub sends back inconsistent data types. For Wink key devices a dictionary is sent back all other Wink devices send back a string. This check now attempts to query the dictionary for the data element and if it is successful the dictionary is converted into a string. If it fails the data is passed along as the string.