### PR TITLE
Updating references to self.pubnubs to self._pubnubs

### DIFF
--- a/pubnubsubhandler.py
+++ b/pubnubsubhandler.py
@@ -103,11 +103,11 @@ class PubNubSubscriptionHandler():
         Completly stop all pubnub operations.
         """
         _LOGGER.info("PubNub unsubscribing")
-        for pubnub in self.pubnubs:
+        for pubnub in self._pubnubs:
             pubnub.unsubscribe_all()
             pubnub.stop()
             pubnub = None
-        self.pubnubs.clear()
+        self._pubnubs.clear()
 
     def _subscribe(self):
         """


### PR DESCRIPTION
Howdy! I noticed during shutdown of my Home Assistant instance that an exception is thrown in this library. This appears to prevent HA from closing gracefully, meaning that systemctl (in my case) kills the process after a timeout.

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/wink/__init__.py", line 404, in stop_subscription
    hass.data[DOMAIN]["pubnub"].unsubscribe()
 File "/srv/homeassistant/lib/python3.7/site-packages/pubnubsubhandler.py", line 106, in unsubscribe
    for pubnub in self.pubnubs:
AttributeError: 'PubNubSubscriptionHandler' object has no attribute 'pubnubs'
```

I fixed up the references to self._pubnubs and I also quickly grepped for other references to self.<variable> without a leading underscore.

After patching my installation in-place I don't see exceptions being thrown and HA shuts down within a second or two.